### PR TITLE
P1: Install CoopCollectibles Protocol as Forge Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "lib/coop-records-collectible-protocol"]
+	path = lib/coop-records-collectible-protocol
+	url = https://github.com/Coop-Records/coop-records-collectible-protocol


### PR DESCRIPTION
   actual: The CoopCollectibles protocol codebase is not available in the project, preventing access to required contracts.
   required: - Install the CoopCollectibles protocol as a git submodule using Forge
   Use repository URL: https://github.com/Coop-Records/coop-records-collectible-protocol
   Ensure the submodule is properly configured in the lib directory
   Verify contracts can be successfully imported from the submodule
   Update .gitmodules file appropriately
   Add installation steps to development documentation