### PR TITLE
P1: Remove Unused CoopCollectibles Protocol Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-[submodule "lib/coop-records-collectible-protocol"]
-	path = lib/coop-records-collectible-protocol
-	url = https://github.com/Coop-Records/coop-records-collectible-protocol


### PR DESCRIPTION
   actual: The Git submodule lib/coop-records-collectible-protocol is included in the codebase but not used anywhere.
   required:
   Remove the Git submodule properly using the standard Git submodule removal process:
   Deregister the submodule entries in .git/config
   Remove the submodule directory from the working tree
   Remove the submodule entry from .gitmodules file
   Commit the changes to repository
   Verify build/tests still pass after removal
   Update any documentation that references the submodule