### PR TITLE
P1: Add fixedPriceSaleStrategy Parameter to Contract Initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ RPC_URL=           # The RPC URL of the target network (e.g., https://sepolia.ba
 PRIVATE_KEY=       # Your wallet's private key for deployment
 TOKEN_URI=         # The URI for the token metadata (e.g., ipfs://...)
 BASESCAN_API_KEY=  # API key for contract verification
+FIXED_PRICE_SALE_STRATEGY= # (Optional) Address of the fixed price sale strategy contract
 ```
 
 2. Run the deployment script:
@@ -122,7 +123,7 @@ forge clean && forge script script/Deploy.s.sol:DeployCredits --rpc-url $RPC_URL
 
 4. Update contract configuration (if needed):
 
-   - Set the fixed price sale strategy: `cast send <PROXY_ADDRESS> "setFixedPriceSaleStrategy(address)" <STRATEGY_ADDRESS> --rpc-url $RPC_URL --private-key $PRIVATE_KEY`
+   - Set the fixed price sale strategy (only if not provided during initialization): `cast send <PROXY_ADDRESS> "setFixedPriceSaleStrategy(address)" <STRATEGY_ADDRESS> --rpc-url $RPC_URL --private-key $PRIVATE_KEY`
 
 5. Verify deployment by testing core functionality:
    - Buy credits: `cast send <PROXY_ADDRESS> "buyCredits(address,uint256)" <RECIPIENT_ADDRESS> <AMOUNT> --value <ETH_AMOUNT> --rpc-url $RPC_URL --private-key $PRIVATE_KEY`

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -21,12 +21,12 @@ contract DeployCredits is Script {
     ProxyAdmin public proxyAdmin;
 
     function run() public returns (DeploymentResult memory) {
-        address marketAddress = vm.envAddress("MARKET_ADDRESS");
         string memory tokenUri = vm.envString("TOKEN_URI");
+        address fixedPriceSaleStrategy = vm.envOr("FIXED_PRICE_SALE_STRATEGY", address(0));
 
         console.log("Deploying Credits1155 to chain:", block.chainid);
-        console.log("Using market address:", marketAddress);
         console.log("Using token URI:", tokenUri);
+        console.log("Using fixed price sale strategy:", fixedPriceSaleStrategy);
 
         // Start broadcasting
         vm.startBroadcast();
@@ -41,7 +41,7 @@ contract DeployCredits is Script {
 
         // 3. Prepare initialization data
         bytes memory initData =
-            abi.encodeWithSelector(Credits1155.initialize.selector, tokenUri, payable(marketAddress));
+            abi.encodeWithSelector(Credits1155.initialize.selector, tokenUri, fixedPriceSaleStrategy);
 
         // 4. Deploy and initialize proxy
         TransparentUpgradeableProxy proxy =

--- a/src/Credits1155.sol
+++ b/src/Credits1155.sol
@@ -127,10 +127,7 @@ contract Credits1155 is
 
         // Set the fixed price sale strategy if provided
         if (_fixedPriceSaleStrategy != address(0)) {
-            if (_fixedPriceSaleStrategy.code.length == 0) {
-                revert Credits1155_Contract_Address_Is_Not_A_Contract();
-            }
-            fixedPriceSaleStrategy = IMinter1155(_fixedPriceSaleStrategy);
+            setFixedPriceSaleStrategy(_fixedPriceSaleStrategy);
         }
     }
 
@@ -138,7 +135,7 @@ contract Credits1155 is
      * @notice Set the fixed price sale strategy for CoopCollectibles
      * @param _fixedPriceSaleStrategy The address of the fixed price sale strategy
      */
-    function setFixedPriceSaleStrategy(address _fixedPriceSaleStrategy) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setFixedPriceSaleStrategy(address _fixedPriceSaleStrategy) public onlyRole(DEFAULT_ADMIN_ROLE) {
         if (_fixedPriceSaleStrategy.code.length == 0) {
             revert Credits1155_Contract_Address_Is_Not_A_Contract();
         }

--- a/src/Credits1155.sol
+++ b/src/Credits1155.sol
@@ -119,11 +119,19 @@ contract Credits1155 is
         _disableInitializers();
     }
 
-    function initialize(string memory tokenUri) public initializer {
+    function initialize(string memory tokenUri, address _fixedPriceSaleStrategy) public initializer {
         __ERC1155_init(tokenUri); // creates first token
         __Ownable_init(msg.sender);
         __AccessControl_init();
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+
+        // Set the fixed price sale strategy if provided
+        if (_fixedPriceSaleStrategy != address(0)) {
+            if (_fixedPriceSaleStrategy.code.length == 0) {
+                revert Credits1155_Contract_Address_Is_Not_A_Contract();
+            }
+            fixedPriceSaleStrategy = IMinter1155(_fixedPriceSaleStrategy);
+        }
     }
 
     /**

--- a/test/Credits1155Initializer.t.sol
+++ b/test/Credits1155Initializer.t.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
+import {Credits1155} from "../src/Credits1155.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+// Import our mock implementations
+import {MockFixedPriceSaleStrategy} from "./mocks/MockFixedPriceSaleStrategy.sol";
+import {MockCoopCreator1155} from "./mocks/MockCoopCreator1155.sol";
+
+contract Credits1155InitializerTest is Test {
+    Credits1155 public implementation;
+    Credits1155 public credits;
+    ProxyAdmin public proxyAdmin;
+    MockFixedPriceSaleStrategy public saleStrategy;
+    MockCoopCreator1155 public coopCollectibles;
+
+    address public owner;
+    address public user;
+    uint256 public constant TOKEN_ID = 123;
+
+    // Event definition for testing
+    event MintWithCreditsFromFixedPriceSale(
+        uint256 indexed tokenId,
+        address indexed tokenRecipient,
+        address indexed referrer,
+        uint256 tokenQuantity,
+        uint256 creditsCost,
+        uint256 ethCost
+    );
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        user = makeAddr("user");
+        vm.deal(user, 100 ether);
+
+        vm.startPrank(owner);
+
+        // Deploy implementation
+        implementation = new Credits1155();
+
+        // Deploy ProxyAdmin with owner
+        proxyAdmin = new ProxyAdmin(owner);
+
+        // Deploy mock implementations
+        coopCollectibles = new MockCoopCreator1155();
+        saleStrategy = new MockFixedPriceSaleStrategy(0.0004 ether);
+
+        // Set up test token
+        coopCollectibles.setupNewToken(TOKEN_ID, "ipfs://test/token", 1000);
+
+        // Set up a valid sale for TOKEN_ID
+        MockFixedPriceSaleStrategy.SalesConfig memory config = MockFixedPriceSaleStrategy.SalesConfig({
+            saleStart: uint64(0),
+            saleEnd: uint64(block.timestamp + 1000),
+            maxTokensPerAddress: 0,
+            pricePerToken: uint96(0.0004 ether),
+            fundsRecipient: payable(owner),
+            exists: true
+        });
+        saleStrategy.setSale(address(coopCollectibles), TOKEN_ID, config);
+
+        vm.stopPrank();
+    }
+
+    function test_Initialize_WithFixedPriceSaleStrategy() public {
+        vm.startPrank(owner);
+
+        // Encode initialization data with the strategy
+        bytes memory initData =
+            abi.encodeWithSelector(Credits1155.initialize.selector, "ipfs://test", address(saleStrategy));
+
+        // Deploy and initialize proxy
+        TransparentUpgradeableProxy proxy =
+            new TransparentUpgradeableProxy(address(implementation), address(proxyAdmin), initData);
+
+        // Setup proxy interface
+        credits = Credits1155(payable(address(proxy)));
+
+        vm.stopPrank();
+
+        // Verify the strategy was set during initialization
+        assertEq(
+            address(credits.fixedPriceSaleStrategy()),
+            address(saleStrategy),
+            "FixedPriceSaleStrategy not set during initialization"
+        );
+    }
+
+    function test_Initialize_WithZeroAddressStrategy() public {
+        vm.startPrank(owner);
+
+        // Encode initialization data with zero address strategy
+        bytes memory initData = abi.encodeWithSelector(
+            Credits1155.initialize.selector,
+            "ipfs://test",
+            address(0) // Zero address for strategy
+        );
+
+        // Deploy and initialize proxy
+        TransparentUpgradeableProxy proxy =
+            new TransparentUpgradeableProxy(address(implementation), address(proxyAdmin), initData);
+
+        // Setup proxy interface
+        credits = Credits1155(payable(address(proxy)));
+
+        vm.stopPrank();
+
+        // Verify the strategy was not set (should be zero address)
+        assertEq(address(credits.fixedPriceSaleStrategy()), address(0), "FixedPriceSaleStrategy should be zero address");
+    }
+
+    function test_Initialize_WithInvalidContractAddress() public {
+        vm.startPrank(owner);
+
+        // Use an EOA (not a contract) for the strategy
+        address nonContractAddress = makeAddr("nonContract");
+
+        // Encode initialization data with invalid address
+        bytes memory initData =
+            abi.encodeWithSelector(Credits1155.initialize.selector, "ipfs://test", nonContractAddress);
+
+        // This should revert when trying to initialize with a non-contract address
+        vm.expectRevert(Credits1155.Credits1155_Contract_Address_Is_Not_A_Contract.selector);
+
+        // Deploy and initialize proxy
+        new TransparentUpgradeableProxy(address(implementation), address(proxyAdmin), initData);
+
+        vm.stopPrank();
+    }
+
+    function test_MintWithCredits_WorksImmediatelyAfterInitialization() public {
+        // Deploy with strategy set during initialization
+        vm.startPrank(owner);
+
+        // Encode initialization data with the strategy
+        bytes memory initData =
+            abi.encodeWithSelector(Credits1155.initialize.selector, "ipfs://test", address(saleStrategy));
+
+        // Deploy and initialize proxy
+        TransparentUpgradeableProxy proxy =
+            new TransparentUpgradeableProxy(address(implementation), address(proxyAdmin), initData);
+
+        // Setup proxy interface
+        credits = Credits1155(payable(address(proxy)));
+
+        vm.stopPrank();
+
+        // Buy some credits for the user
+        uint256 creditsAmount = 10;
+        uint256 cost = credits.getEthCostForCredits(creditsAmount);
+        vm.prank(user);
+        credits.buyCredits{value: cost}(user, creditsAmount);
+
+        // Verify the user actually has credits before proceeding
+        uint256 actualBalance = credits.balanceOf(user, credits.CREDITS_TOKEN_ID());
+        console.log("User credit balance:", actualBalance);
+        assertEq(actualBalance, creditsAmount, "Credits were not minted correctly");
+
+        // Mint tokens with credits immediately after initialization
+        // We should be able to mint without calling setFixedPriceSaleStrategy
+        uint256 tokenQuantity = 2;
+
+        vm.prank(user);
+
+        // Expect the event to be emitted
+        vm.expectEmit(true, true, true, false);
+        emit MintWithCreditsFromFixedPriceSale(
+            TOKEN_ID, user, address(0), tokenQuantity, tokenQuantity, credits.getEthCostForCredits(tokenQuantity)
+        );
+        vm.prank(user);
+
+        // This should succeed without needing to call setFixedPriceSaleStrategy
+        credits.mintWithCredits(address(coopCollectibles), TOKEN_ID, tokenQuantity, user, payable(address(0)));
+
+        // Verify tokens were minted
+        assertEq(coopCollectibles.balanceOf(user, TOKEN_ID), tokenQuantity, "Tokens were not minted correctly");
+    }
+}

--- a/test/Credits1155Initializer.t.sol
+++ b/test/Credits1155Initializer.t.sol
@@ -178,5 +178,10 @@ contract Credits1155InitializerTest is Test {
 
         // Verify tokens were minted
         assertEq(coopCollectibles.balanceOf(user, TOKEN_ID), tokenQuantity, "Tokens were not minted correctly");
+
+        // Verify credits were deducted
+        uint256 finalCreditBalance = credits.balanceOf(user, credits.CREDITS_TOKEN_ID());
+        console.log("User final credit balance:", finalCreditBalance);
+        assertEq(finalCreditBalance, creditsAmount - tokenQuantity, "Credits were not deducted correctly");
     }
 }


### PR DESCRIPTION
    actual: After deployment, the credits protocol requires a separate setFixedPriceSaleStrategy call to enable credit functionality.
    required:
    Update the initialize method signature to include a \_fixedPriceSaleStrategy parameter
    Modify the initialize method implementation to set the fixedPriceSaleStrategy during initialization
    Ensure backward compatibility with existing tests
    Update deployment scripts to provide the strategy address during initialization
    Verify the protocol works immediately after deployment without additional method calls
    Update contract documentation to reflect the new parameter requirement