### PR TITLE
P1: Remove Global State in mintWithCredits Function

### DIFF
--- a/src/Credits1155.sol
+++ b/src/Credits1155.sol
@@ -37,11 +37,6 @@ contract Credits1155 is
     uint256 public constant MINT_FEE_IN_WEI = 0.0004 ether;
 
     /**
-     * @notice CoopCollectibles contract for minting tokens using credits.
-     */
-    ICoopCreator1155 public coopCollectibles;
-
-    /**
      * @notice Fixed price sale strategy contract
      */
     IMinter1155 public fixedPriceSaleStrategy;
@@ -202,7 +197,7 @@ contract Credits1155 is
         if (coopCollectiblesAddress.code.length == 0) {
             revert Credits1155_Contract_Address_Is_Not_A_Contract();
         }
-        coopCollectibles = ICoopCreator1155(coopCollectiblesAddress);
+        ICoopCreator1155 coopCollectibles = ICoopCreator1155(coopCollectiblesAddress);
         if (tokenQuantity < 1) {
             revert Credits1155_Must_Buy_At_Least_One_Token();
         }

--- a/test/Credits1155Isolation.t.sol
+++ b/test/Credits1155Isolation.t.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
+import {Credits1155} from "../src/Credits1155.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+// Import our mock implementations
+import {MockCoopCreator1155} from "./mocks/MockCoopCreator1155.sol";
+import {MockFixedPriceSaleStrategy} from "./mocks/MockFixedPriceSaleStrategy.sol";
+
+/**
+ * @title Credits1155IsolationTest
+ * @dev Tests focused on ensuring the mintWithCredits function handles different
+ * collectibles contracts in isolation, without persisting state between calls
+ */
+contract Credits1155IsolationTest is Test {
+    Credits1155 public implementation;
+    Credits1155 public credits;
+    ProxyAdmin public proxyAdmin;
+    MockFixedPriceSaleStrategy public saleStrategy;
+
+    // Multiple mock collectibles contracts for cross-contract testing
+    MockCoopCreator1155 public collectibles1;
+    MockCoopCreator1155 public collectibles2;
+
+    address public owner;
+    address public user;
+    uint256 public constant TOKEN_ID = 123;
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        user = makeAddr("user");
+        vm.deal(user, 100 ether);
+
+        vm.startPrank(owner);
+
+        // Deploy implementation
+        implementation = new Credits1155();
+
+        // Deploy ProxyAdmin with owner
+        proxyAdmin = new ProxyAdmin(owner);
+
+        // Deploy mock implementations
+        collectibles1 = new MockCoopCreator1155();
+        collectibles2 = new MockCoopCreator1155();
+        saleStrategy = new MockFixedPriceSaleStrategy(0.0004 ether);
+
+        // Set up test tokens in both collectibles contracts
+        collectibles1.setupNewToken(TOKEN_ID, "ipfs://test/token1", 1000);
+        collectibles2.setupNewToken(TOKEN_ID, "ipfs://test/token2", 1000);
+
+        // Set up sales in the strategy for both collectibles
+        MockFixedPriceSaleStrategy.SalesConfig memory config = MockFixedPriceSaleStrategy.SalesConfig({
+            saleStart: uint64(0),
+            saleEnd: uint64(block.timestamp + 1000),
+            maxTokensPerAddress: 0,
+            pricePerToken: uint96(0.0004 ether),
+            fundsRecipient: payable(owner),
+            exists: true
+        });
+
+        saleStrategy.setSale(address(collectibles1), TOKEN_ID, config);
+        saleStrategy.setSale(address(collectibles2), TOKEN_ID, config);
+
+        // Initialize and deploy the proxy with our implementation
+        bytes memory initData =
+            abi.encodeWithSelector(Credits1155.initialize.selector, "ipfs://test", address(saleStrategy));
+
+        TransparentUpgradeableProxy proxy =
+            new TransparentUpgradeableProxy(address(implementation), address(proxyAdmin), initData);
+
+        // Setup proxy interface
+        credits = Credits1155(payable(address(proxy)));
+
+        vm.stopPrank();
+
+        // Buy credits for the user
+        uint256 creditsAmount = 100; // Enough for multiple mints
+        uint256 cost = credits.getEthCostForCredits(creditsAmount);
+        vm.prank(user);
+        credits.buyCredits{value: cost}(user, creditsAmount);
+    }
+
+    /**
+     * @notice Tests the isolation property of mintWithCredits with multiple collectibles contracts
+     * @dev Verifies that:
+     *      1. Minting works correctly with an initial collectibles contract
+     *      2. Minting with a different collectibles contract also succeeds
+     *      3. Returning to the first contract works without issues
+     *      This confirms mintWithCredits doesn't maintain harmful state between calls
+     */
+    function test_MintWithCredits_MaintainsIsolationBetweenCalls() public {
+        uint256 tokenQuantity = 1;
+
+        // First mint with collectibles1
+        vm.prank(user);
+        credits.mintWithCredits(address(collectibles1), TOKEN_ID, tokenQuantity, user, payable(address(0)));
+
+        // Verify mint worked with collectibles1
+        uint256 balance1 = collectibles1.balanceOf(user, TOKEN_ID);
+        assertEq(balance1, tokenQuantity, "First mint with collectibles1 failed");
+        console.log("First mint with collectibles1 successful");
+
+        // Mint with collectibles2
+        vm.prank(user);
+        credits.mintWithCredits(address(collectibles2), TOKEN_ID, tokenQuantity, user, payable(address(0)));
+
+        // Verify mint worked with collectibles2
+        uint256 balance2 = collectibles2.balanceOf(user, TOKEN_ID);
+        assertEq(balance2, tokenQuantity, "Second mint with collectibles2 failed");
+        console.log("Second mint with collectibles2 successful");
+
+        // Verify we can mint again with collectibles1 without issues
+        vm.prank(user);
+        credits.mintWithCredits(address(collectibles1), TOKEN_ID, tokenQuantity, user, payable(address(0)));
+
+        // Verify the additional tokens were minted from collectibles1
+        uint256 newBalance1 = collectibles1.balanceOf(user, TOKEN_ID);
+        assertEq(newBalance1, balance1 + tokenQuantity, "Third mint with collectibles1 failed");
+        console.log("Third mint with collectibles1 successful");
+
+        // Test passes if all mints work correctly, confirming proper isolation
+        console.log("All sequential mints completed successfully without state interference");
+    }
+}


### PR DESCRIPTION
    actual: The mintWithCredits function currently sets and uses a global coopCollectibles variable, creating potential side effects.
    required:
    Delete the global coopCollectibles variable declaration
    Refactor mintWithCredits to declare and use a local variable within function scope
    Ensure the variable has no persistence after the function completes
    Verify all functionality remains unchanged after refactoring
    Update any tests that may have been relying on the global variable